### PR TITLE
Support hyperlink

### DIFF
--- a/CopyFromExcelToMarkdownAddIn/CopyFromExcelToMarkdownAddIn/ThisAddIn.cs
+++ b/CopyFromExcelToMarkdownAddIn/CopyFromExcelToMarkdownAddIn/ThisAddIn.cs
@@ -170,7 +170,15 @@ namespace CopyFromExcelToMarkdownAddIn
                 var cell = (Range)range.Cells[1, x];
 
                 resultBuffer.Append("|");
-                resultBuffer.Append(cell.FormatText());
+                if (cell.Hyperlinks.Count > 0)
+                {
+                    resultBuffer.Append("[").Append(cell.FormatText()).Append("]")
+                            .Append("(").Append(cell.Hyperlinks[1].Address).Append(")");
+                }
+                else
+                {
+                    resultBuffer.Append(cell.FormatText());
+                }
                 switch ((int)cell.HorizontalAlignment)
                 {
                     case AlignmentLeft:
@@ -202,7 +210,15 @@ namespace CopyFromExcelToMarkdownAddIn
                     var cell = (Range)range.Cells[y, x];
 
                     resultBuffer.Append("|");
-                    resultBuffer.Append(cell.FormatText());
+                    if (cell.Hyperlinks.Count > 0)
+                    {
+                        resultBuffer.Append("[").Append(cell.FormatText()).Append("]")
+                            .Append("(").Append(cell.Hyperlinks[1].Address).Append(")");
+                    }
+                    else
+                    {
+                        resultBuffer.Append(cell.FormatText());
+                    }
                 }
                 resultBuffer.Append("|");
                 resultBuffer.Append(Environment.NewLine);

--- a/CopyFromExcelToMarkdownAddIn/CopyFromExcelToMarkdownAddIn/ThisAddIn.cs
+++ b/CopyFromExcelToMarkdownAddIn/CopyFromExcelToMarkdownAddIn/ThisAddIn.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 using Microsoft.Office.Core;
 using Microsoft.Office.Interop.Excel;
@@ -107,7 +108,14 @@ namespace CopyFromExcelToMarkdownAddIn
                 {
                     var cell = row[j];
                     var activeSheetCell =  (Range)activeSheet.Cells[range.Row + i, range.Column + j];
-                    activeSheetCell.Value2 = cell.Value
+                    var value = cell.Value;
+                    var match = Regex.Match(value, "\\[([^\\]]+)\\]\\(([^\\)]+)\\)");
+                    if (match.Success)
+                    {
+                        activeSheet.Hyperlinks.Add(activeSheetCell, match.Groups[2].Value);
+                        value = value.Replace(match.Value, match.Groups[1].Value);
+                    }
+                    activeSheetCell.Value2 = value
                         .Replace("<br>", "\n")
                         .Replace("<br/>", "\n")
                         .Replace("&#124;", "|");


### PR DESCRIPTION
This PR is to add support for hyperlink. The additional codes are intended to work in both directions, that is, mark down to/from Excel. 
More precisely, if cell value is decorated with a hyperlink, the generated mark donw text is "[text] (link)". On the other hand, is mark down text is link "text1 [text2] (link) text3", the pased cell will be "text1 text2 text3" having a hyperlink to link.

There is no test codes, however, I checked its functionality with VS2022 and the latest Office365 Excel.